### PR TITLE
Core logic modified

### DIFF
--- a/src/main/java/com/fast/discovery/core/DiscoveryHandler.java
+++ b/src/main/java/com/fast/discovery/core/DiscoveryHandler.java
@@ -13,8 +13,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public class DiscoveryHandler {
     private static final Logger log = LogManager.getLogger(DiscoveryHandler.class);
 
-    private static ConcurrentHashMap<String, List<ServiceRegistry.InstanceInfo>> registry =
-            new ConcurrentHashMap<String, List<ServiceRegistry.InstanceInfo>>();
+    private static ConcurrentHashMap<String, ServiceRegistry.InstanceInfo> registry =
+            new ConcurrentHashMap<String, ServiceRegistry.InstanceInfo>();
 
     public Acknowledgement serviceRegistration(ServiceRegistry serviceRegistry) {
         Acknowledgement ack = new Acknowledgement();

--- a/src/main/java/com/fast/discovery/dto/ServiceRegistry.java
+++ b/src/main/java/com/fast/discovery/dto/ServiceRegistry.java
@@ -1,14 +1,12 @@
 package com.fast.discovery.dto;
 
-import java.util.List;
-
 /**
  * @Desc - Microservice Registry DTO
  * @Author - wolfdale
  */
 public class ServiceRegistry {
     private String instanceId;
-    private List<InstanceInfo> instanceInformation;
+    private InstanceInfo instanceInformation;
 
     public static class InstanceInfo {
         private String serviceName;
@@ -57,11 +55,11 @@ public class ServiceRegistry {
         this.instanceId = instanceId;
     }
 
-    public List<InstanceInfo> getInstanceInformation() {
+    public InstanceInfo getInstanceInformation() {
         return instanceInformation;
     }
 
-    public void setInstanceInformation(List<InstanceInfo> instanceInformation) {
+    public void setInstanceInformation(InstanceInfo instanceInformation) {
         this.instanceInformation = instanceInformation;
     }
 }


### PR DESCRIPTION
- Service Registry DTO doesn't require instance info to be a list.
- one to one mapping between InstanceID and Instance Info